### PR TITLE
Fix tempfile.mkstemp

### DIFF
--- a/web_infrastructure/jenkins_plugin.py
+++ b/web_infrastructure/jenkins_plugin.py
@@ -567,7 +567,7 @@ class JenkinsPlugin(object):
             updates_file = tempfile.mkstemp()
 
             try:
-                fd = open(updates_file, 'wb')
+                fd = open(updates_file[1], 'wb')
             except IOError:
                 e = get_exception()
                 self.module.fail_json(
@@ -644,7 +644,7 @@ class JenkinsPlugin(object):
         tmp_f = tempfile.mkstemp()
 
         try:
-            fd = open(tmp_f, 'wb')
+            fd = open(tmp_f[1], 'wb')
         except IOError:
             e = get_exception()
             self.module.fail_json(

--- a/web_infrastructure/jenkins_plugin.py
+++ b/web_infrastructure/jenkins_plugin.py
@@ -564,10 +564,11 @@ class JenkinsPlugin(object):
                 msg_exception="Updates download failed.")
 
             # Write the updates file
-            updates_file = tempfile.mkstemp()
+            updates_file_tuple = tempfile.mkstemp()
+            updates_file =updates_file_tuple[1]
 
             try:
-                fd = open(updates_file[1], 'wb')
+                fd = open(updates_file, 'wb')
             except IOError:
                 e = get_exception()
                 self.module.fail_json(
@@ -641,10 +642,11 @@ class JenkinsPlugin(object):
 
     def _write_file(self, f, data):
         # Store the plugin into a temp file and then move it
-        tmp_f = tempfile.mkstemp()
+        tmp_f_tuple = tempfile.mkstemp()
+        tmp_f =tmp_f_tuple[1]
 
         try:
-            fd = open(tmp_f[1], 'wb')
+            fd = open(tmp_f, 'wb')
         except IOError:
             e = get_exception()
             self.module.fail_json(


### PR DESCRIPTION
- Bugfix Pull Request
##### COMPONENT NAME

jenkins/web_infrastructure/download_plugin
##### ANSIBLE VERSION

```
ansible 2.2.0
  config file =
  configured module search path = Default w/o overrides
```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

The execution of plugin install was failing with TypeError on file.open() and file.read() calls. tempfile.mkstemp() returns a tuple not a file path. 

No existing issue, but the bug was introduced in this PR #2887

<!--- Paste verbatim command output below, e.g. before and after your change -->

```

```
